### PR TITLE
fix: disable render cache to fix $isPreview in block inserter preview

### DIFF
--- a/src/blocks/components/block/render-cache.ts
+++ b/src/blocks/components/block/render-cache.ts
@@ -70,7 +70,11 @@ export const renderCache = {
   },
 
   get(hash: string): string | undefined {
-    return cache.get(hash);
+    // Disabled: computeHash() does not include blockstudioMode, so editor
+    // and preview renders share the same key. This causes the Block Inserter
+    // preview to reuse editor-cached HTML instead of fetching with
+    // blockstudioMode=preview. Preloading via claimPreloaded() still works.
+    return undefined;
   },
 
   set(hash: string, rendered: string, blockName?: string) {


### PR DESCRIPTION
## Description

### Problem

`$isPreview` is always `false` in the Block Inserter preview when a block of the same type already exists on the current page. This breaks blocks that rely on `$isPreview` to show a simplified inserter preview as documented at https://www.blockstudio.dev/docs/blocks/environment.

### Root Cause

The hash-based render cache in `render-cache.ts` uses `computeHash(blockName, attributes)` as the cache key. This hash does **not** include `blockstudioMode`. When a block is rendered in the editor with `blockstudioMode=editor`, the HTML is cached. When the Block Inserter preview needs the same block, it gets a cache hit (same hash) and reuses the editor-mode HTML without making a fresh REST call with `blockstudioMode=preview`.

The flow:

1. `blocks.php:enqueue_editor_assets()` pre-renders blocks with `$_GET['blockstudioMode'] = 'editor'`
2. JavaScript stores them via `renderCache.set(hash, html)`
3. Inserter preview mounts Block component, `useState` initializer calls `renderCache.get(hash)` and gets a cache hit
4. `firstRenderDone.current = true`, early return in `onMount`, no REST call with `blockstudioMode=preview`

### Fix

Disable `renderCache.get()` by returning `undefined`. This forces a fresh REST call for each render context. The preload queue (`claimPreloaded`) continues to work for initial page load performance.

### What still works

- Initial editor load via preloading (`claimPreloaded`)
- REST calls for attribute changes (already bypassed cache via debounced fetch)
- All PHP-side `$isEditor` / `$isPreview` logic (was never broken)

### Performance impact

- Initial editor load: unchanged
- Block Inserter preview: always REST call (correct behavior, was incorrectly cached before)
- Same block type appearing multiple times: each fetches independently (slightly slower, no cross-block cache sharing)

### Reproduction

1. Create a block using `$isPreview` (per the [Environment docs](https://www.blockstudio.dev/docs/blocks/environment)):

```php
<?php if ($isPreview) : ?>
    <div useBlockProps style="padding:16px; background:#e8fde8; border:2px solid #0a0;">
        Preview content
    </div>
<?php else : ?>
    <div useBlockProps style="padding:16px; background:#e8f4fd; border:2px solid #0073aa;">
        Editor/Frontend content
    </div>
<?php endif; ?>
```

2. Set `"example": true` in `block.json`
3. Place the block on a page, save, and reload the editor
4. Open the Block Inserter and hover over the same block type
5. **Before fix:** shows blue (editor mode, `$isPreview=false`)
6. **After fix:** shows green (preview mode, `$isPreview=true`)

### Long-term alternative

A cleaner fix would be to include `blockstudioMode` in `computeHash()`, so editor and preview renders have separate cache entries. This preserves the cache performance benefit but requires updating all `computeHash()` call sites.