### PR TITLE
fix: include blockstudioMode in render cache hash to fix $isPreview in block inserter preview

### DIFF
--- a/src/blocks/components/block/batch-fetcher.ts
+++ b/src/blocks/components/block/batch-fetcher.ts
@@ -54,7 +54,7 @@ const flush = () => {
       batch.forEach((req) => {
         const html = rendered[req.clientId];
         if (html) {
-          const hash = computeHash(req.name, req.attributes);
+          const hash = computeHash(req.name, req.attributes, req.post.blockstudioMode);
           renderCache.set(hash, html, req.name);
           req.resolve(html);
         } else {

--- a/src/blocks/components/block/index.tsx
+++ b/src/blocks/components/block/index.tsx
@@ -200,16 +200,10 @@ export const Block = ({
       return { markup: null, hasMarkup: false, hasBlockProps: null };
     }
 
-    const hash = computeHash(block.name, attributes);
     const preloaded = renderCache.claimPreloaded(block.name, clientId);
 
-    const cached = renderCache.get(hash);
-    if (cached) {
-      firstRenderDone.current = true;
-      return computeRender(cached);
-    }
-
     if (preloaded) {
+      const hash = computeHash(block.name, attributes, 'editor');
       renderCache.set(hash, preloaded, block.name);
       firstRenderDone.current = true;
       return computeRender(preloaded);
@@ -269,7 +263,7 @@ export const Block = ({
     })
       .then((response) => {
         const res = response as { rendered: string };
-        const hash = computeHash(block.name, attributes);
+        const hash = computeHash(block.name, attributes, getPostParams().blockstudioMode);
         renderCache.set(hash, res.rendered, block.name);
         updateRender(res.rendered);
       })
@@ -281,14 +275,25 @@ export const Block = ({
   const debouncedFetchSingle = useDebounce(fetchSingle, 500);
 
   useEffect(function onMount() {
-    setIsInPreview(
-      !!ref.current?.closest('.block-editor-block-preview__content-iframe'),
+    const isPreview = !!ref.current?.closest(
+      '.block-editor-block-preview__content-iframe',
     );
+    setIsInPreview(isPreview);
 
     if (disableLoading) return;
 
     if (firstRenderDone.current && renderState.hasMarkup) {
       loaded();
+      return;
+    }
+
+    const mode = isPreview ? 'preview' : 'editor';
+    const hash = computeHash(block.name, attributes, mode);
+    const cached = renderCache.get(hash);
+    if (cached) {
+      updateRender(cached);
+      loaded();
+      firstRenderDone.current = true;
       return;
     }
 
@@ -327,7 +332,7 @@ export const Block = ({
 
       if (!firstRenderDone.current) return;
 
-      const hash = computeHash(block.name, newAttributes);
+      const hash = computeHash(block.name, newAttributes, getPostParams().blockstudioMode);
       const cached = renderCache.get(hash);
 
       if (cached) {

--- a/src/blocks/components/block/render-cache.ts
+++ b/src/blocks/components/block/render-cache.ts
@@ -21,6 +21,7 @@ const sortedStringify = (value: unknown): string => {
 export const computeHash = (
   blockName: string,
   attributes: unknown,
+  mode: string = 'editor',
 ): string => {
   const cloned = cloneDeep(attributes) as Record<string, unknown>;
   Object.keys(cloned).forEach((key) => {
@@ -39,7 +40,7 @@ export const computeHash = (
     cloned as Parameters<typeof replaceEmptyStringsWithFalse>[0],
   );
 
-  return sortedStringify({ blockName, attrs })
+  return sortedStringify({ blockName, attrs, mode })
     .replaceAll('{', '_')
     .replaceAll('}', '_')
     .replaceAll('[', '_')


### PR DESCRIPTION
## Description

### Problem

`$isPreview` is always `false` in the Block Inserter preview when a block of the same type already exists on the current page. This breaks blocks that rely on `$isPreview` to show a simplified inserter preview as documented at https://www.blockstudio.dev/docs/blocks/environment.

The bug has been present since the introduction of the render cache in v7 and persists through v7.1.2.

### Root Cause

The hash-based render cache in `render-cache.ts` uses `computeHash(blockName, attributes)` as the cache key. This hash does **not** include `blockstudioMode`. When a block is rendered in the editor (`blockstudioMode=editor`), the HTML is cached. When the Block Inserter preview needs the same block, it gets a cache hit (same hash) and reuses the editor-mode HTML without making a fresh REST call with `blockstudioMode=preview`.

The flow:

1. `blocks.php:enqueue_editor_assets()` pre-renders blocks with `$_GET['blockstudioMode'] = 'editor'`
2. JavaScript stores them via `renderCache.set(hash, html)` where hash = `computeHash(blockName, attributes)`
3. Inserter preview mounts `Block` component, `useState` initializer calls `renderCache.get(hash)` and gets a cache hit
4. `firstRenderDone.current = true`, early return in `onMount` effect, no REST call with `blockstudioMode=preview`

### Fix

Include `blockstudioMode` in `computeHash()` so that editor renders (`mode=editor`) and preview renders (`mode=preview`) produce different cache keys. This way the cache correctly separates content by rendering context.

The fix involves three files:

**`render-cache.ts`** — Add `mode` parameter to `computeHash()`:

```typescript
export const computeHash = (
  blockName: string,
  attributes: unknown,
  mode: string = 'editor',  // NEW
): string => {
  // ... existing cleanup ...
  return sortedStringify({ blockName, attrs, mode })  // mode included in hash
    // ... existing replacements ...
};
```

**`index.tsx`** — Four changes:

1. **useState initializer:** Remove the `renderCache.get(hash)` lookup (mode is unknown before mount because `ref.current` is `null`). Keep only `claimPreloaded()`, which correctly serves preloaded editor-mode HTML to page blocks. Preloads are stored with explicit `mode='editor'`.

2. **onMount effect:** Add a hash-cache lookup with the correct mode (determined via `ref.current?.closest('.block-editor-block-preview__content-iframe')`). This runs after mount when the DOM ref is available.

3. **fetchSingle response handler:** Pass `getPostParams().blockstudioMode` as the mode when storing in cache.

4. **onAttributeOrContextChange:** Pass `getPostParams().blockstudioMode` as the mode when reading from cache.

**`batch-fetcher.ts`** — Pass `req.post.blockstudioMode` as the mode when storing batch render results in cache.

### Why this approach

The previous fix proposal (disabling `renderCache.get()` entirely) worked but sacrificed all hash-based caching. This approach preserves cache performance:

| Scenario | Previous fix (cache disabled) | This fix (mode in hash) |
|----------|-------------------------------|------------------------|
| Initial editor load | Preload (fast) | Preload (fast) |
| Inserter preview | REST call (correct) | REST call (correct) |
| Same block type 2x on page | 2x REST call (slower) | Cache hit (fast) |
| Attribute change + undo | REST call (slower) | Cache hit (fast) |

### Why the hash-cache lookup moves from useState to onMount

The `useState` initializer runs before the component mounts, so `ref.current` is `null` at that point. The rendering mode can only be determined by checking whether the component's DOM node is inside a `.block-editor-block-preview__content-iframe`. Note that `document.documentElement.classList.contains(...)` does NOT work because React code runs in the parent window's JS context, not inside the preview iframe.

Moving the hash-cache check to `onMount` (where `ref.current` is available) solves this cleanly. The `claimPreloaded()` call remains in `useState` because preloaded blocks are always `editor` mode (from PHP preloading in `blocks.php`), and page blocks consume the preload queue before the inserter preview ever mounts.

### What still works

- Initial editor load via preloading (`claimPreloaded`)
- Hash-based caching for same-mode renders (e.g. two identical blocks in editor)
- REST calls for attribute changes (debounced fetch, now stored with correct mode)
- All PHP-side `$isEditor` / `$isPreview` logic (was never broken)
- `replacePreloads()` cache invalidation (uses `cacheByBlock` map, unaffected by hash format change)

### Reproduction

1. Create a block using `$isPreview` (per the [Environment docs](https://www.blockstudio.dev/docs/blocks/environment)):

```php
<?php if ($isPreview) : ?>
    <div useBlockProps style="padding:16px; background:#e8fde8; border:2px solid #0a0;">
        Preview mode
    </div>
<?php else : ?>
    <div useBlockProps style="padding:16px; background:#e8f4fd; border:2px solid #0073aa;">
        Editor/Frontend mode
    </div>
<?php endif; ?>
```

2. Set `"example": true` in `block.json`
3. Place the block on a page, save, and reload the editor
4. Open the Block Inserter and hover over the same block type
5. **Before fix:** shows blue border (editor mode, `$isPreview=false`)
6. **After fix:** shows green border (preview mode, `$isPreview=true`)

### Changes

```
 src/blocks/components/block/render-cache.ts  |  3 ++-
 src/blocks/components/block/index.tsx        | 27 ++++++++++++++++-----------
 src/blocks/components/block/batch-fetcher.ts |  2 +-
 3 files changed, 19 insertions(+), 13 deletions(-)
```
