### PR TITLE
Elect a single compiler per cold compiled asset

### DIFF
--- a/includes/classes/assets.php
+++ b/includes/classes/assets.php
@@ -87,6 +87,17 @@ class Assets {
 	private const SELECTOR_PLACEHOLDER_CLASS = '__blockstudio-selector-placeholder__';
 
 	/**
+	 * Wait budget for requests contending on a cold compiled asset in ms.
+	 *
+	 * Mirrors the runtime build election in Build::init(): contending
+	 * requests wait this long for the elected compiler to publish, then
+	 * compile unguarded.
+	 *
+	 * @var int
+	 */
+	private const COMPILE_WAIT_BUDGET_MS = 5000;
+
+	/**
 	 * Loaded modules.
 	 *
 	 * @var array
@@ -1746,6 +1757,63 @@ class Assets {
 	}
 
 	/**
+	 * Compile a cold asset exactly once across concurrent requests.
+	 *
+	 * Single_Flight::publish() makes the write atomic, but the compile
+	 * itself was unguarded: N concurrent requests on a missing compiled
+	 * file each ran the full compile, then published identical bytes. One
+	 * request per compiled filename is elected via a Single_Flight lock
+	 * and runs the compiler; contending requests wait a bounded time for
+	 * the published file to appear instead of duplicating the work. A
+	 * request whose wait budget expires compiles unguarded so asset
+	 * processing always completes, matching the runtime build election in
+	 * Build::init().
+	 *
+	 * @param string   $compiled_filename The compiled file path.
+	 * @param callable $compiler          Returns the content to publish.
+	 *
+	 * @return bool Whether the compiled file is published.
+	 */
+	private static function compile_once( string $compiled_filename, callable $compiler ): bool {
+		$lock = Single_Flight::acquire( $compiled_filename . '.lock' );
+
+		if ( false === $lock ) {
+			$published = Single_Flight::wait(
+				static function () use ( $compiled_filename ): ?bool {
+					clearstatcache( true, $compiled_filename );
+
+					return file_exists( $compiled_filename ) ? true : null;
+				},
+				self::COMPILE_WAIT_BUDGET_MS
+			);
+
+			if ( true === $published ) {
+				return true;
+			}
+
+			$lock = Single_Flight::acquire( $compiled_filename . '.lock' );
+
+			if ( false === $lock ) {
+				$lock = null;
+			}
+		}
+
+		try {
+			clearstatcache( true, $compiled_filename );
+
+			if ( file_exists( $compiled_filename ) ) {
+				return true;
+			}
+
+			return Single_Flight::publish( $compiled_filename, (string) $compiler() );
+		} finally {
+			if ( is_resource( $lock ) ) {
+				Single_Flight::release( $lock );
+			}
+		}
+	}
+
+	/**
 	 * Transform CSS assets and print to file.
 	 *
 	 * @param string $path         The file path.
@@ -1776,26 +1844,33 @@ class Assets {
 			return;
 		}
 
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local file.
-		$data = apply_filters( 'blockstudio/assets/process/css/content', file_get_contents( $path ) );
-		$data = self::replace_selector_placeholder( $data, $scoped_class, $scope_css );
+		$published = self::compile_once(
+			$compiled_filename,
+			static function () use ( $path, $scoped_class, $process_scss, $scope_css, $minify_css ): string {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading local file.
+				$data = apply_filters( 'blockstudio/assets/process/css/content', file_get_contents( $path ) );
+				$data = self::replace_selector_placeholder( $data, $scoped_class, $scope_css );
 
-		if ( $process_scss ) {
-			$data = self::compile_scss( $data, $path );
-		}
+				if ( $process_scss ) {
+					$data = self::compile_scss( $data, $path );
+				}
 
-		if ( $scope_css ) {
-			$data = self::prefix_css( $data, '.' . $scoped_class );
-			$data = self::resolve_scoped_selector_placeholder( $data, $scoped_class );
-		}
+				if ( $scope_css ) {
+					$data = self::prefix_css( $data, '.' . $scoped_class );
+					$data = self::resolve_scoped_selector_placeholder( $data, $scoped_class );
+				}
 
-		if ( $minify_css ) {
-			$minifier = new Minify\CSS();
-			$minifier->add( $data );
-			$data = $minifier->minify();
-		}
+				if ( $minify_css ) {
+					$minifier = new Minify\CSS();
+					$minifier->add( $data );
+					$data = $minifier->minify();
+				}
 
-		if ( ! Single_Flight::publish( $compiled_filename, $data ) ) {
+				return $data;
+			}
+		);
+
+		if ( ! $published ) {
 			return;
 		}
 
@@ -1851,17 +1926,22 @@ class Assets {
 			);
 		}
 
-		if ( $minify_js ) {
-			$minifier = new Minify\JS();
-			$minifier->add( $data );
-			$data = $minifier->minify();
-		}
+		if ( $minify_js || $has_es_modules || $has_css_modules ) {
+			$published = self::compile_once(
+				$compiled_filename,
+				static function () use ( $data, $minify_js ): string {
+					if ( ! $minify_js ) {
+						return $data;
+					}
 
-		if (
-			! file_exists( $compiled_filename ) &&
-			( $minify_js || $has_es_modules || $has_css_modules )
-		) {
-			if ( ! Single_Flight::publish( $compiled_filename, $data ) ) {
+					$minifier = new Minify\JS();
+					$minifier->add( $data );
+
+					return $minifier->minify();
+				}
+			);
+
+			if ( ! $published ) {
 				return;
 			}
 

--- a/tests/unit/assets/AssetsTest.php
+++ b/tests/unit/assets/AssetsTest.php
@@ -3,6 +3,7 @@
 use Blockstudio\Assets;
 use Blockstudio\Block;
 use Blockstudio\Build;
+use Blockstudio\Single_Flight;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
@@ -918,5 +919,99 @@ class AssetsTest extends TestCase {
 		}
 
 		$this->assertFalse( $started );
+	}
+
+	public function test_compile_once_publishes_a_cold_asset(): void {
+		$compiled = $this->temporary_compiled_path();
+		$calls    = 0;
+
+		$published = $this->compile_once(
+			$compiled,
+			static function () use ( &$calls ): string {
+				++$calls;
+
+				return '.cold { color: red; }';
+			}
+		);
+
+		$this->assertTrue( $published );
+		$this->assertSame( 1, $calls );
+		$this->assertFileExists( $compiled );
+		$this->assertSame( '.cold { color: red; }', file_get_contents( $compiled ) );
+	}
+
+	public function test_compile_once_skips_the_compiler_when_the_asset_is_already_published(): void {
+		$compiled = $this->temporary_compiled_path();
+		$calls    = 0;
+
+		wp_mkdir_p( dirname( $compiled ) );
+		file_put_contents( $compiled, '.published { color: red; }' );
+
+		$published = $this->compile_once(
+			$compiled,
+			static function () use ( &$calls ): string {
+				++$calls;
+
+				return '.duplicate { color: blue; }';
+			}
+		);
+
+		$this->assertTrue( $published );
+		$this->assertSame( 0, $calls );
+		$this->assertSame( '.published { color: red; }', file_get_contents( $compiled ) );
+	}
+
+	public function test_compile_once_skips_the_compiler_when_another_request_published_under_the_lock(): void {
+		$compiled = $this->temporary_compiled_path();
+		$calls    = 0;
+
+		wp_mkdir_p( dirname( $compiled ) );
+
+		// flock() locks an open file description, so a second acquire() contends
+		// here exactly as a concurrent request would.
+		$lock = Single_Flight::acquire( $compiled . '.lock' );
+		$this->assertIsResource( $lock );
+		$this->assertFalse( Single_Flight::acquire( $compiled . '.lock' ) );
+
+		file_put_contents( $compiled, '.published { color: red; }' );
+
+		$published = $this->compile_once(
+			$compiled,
+			static function () use ( &$calls ): string {
+				++$calls;
+
+				return '.duplicate { color: blue; }';
+			}
+		);
+
+		Single_Flight::release( $lock );
+
+		$this->assertTrue( $published );
+		$this->assertSame( 0, $calls );
+		$this->assertSame( '.published { color: red; }', file_get_contents( $compiled ) );
+	}
+
+	public function test_compile_once_releases_the_lock_after_publishing(): void {
+		$compiled = $this->temporary_compiled_path();
+
+		$this->compile_once( $compiled, static fn (): string => '.cold { color: red; }' );
+
+		$lock = Single_Flight::acquire( $compiled . '.lock' );
+
+		$this->assertIsResource( $lock );
+
+		Single_Flight::release( $lock );
+	}
+
+	private function temporary_compiled_path(): string {
+		$source = $this->create_temporary_asset( 'style.css', '.source { color: red; }' );
+
+		return dirname( $source ) . '/_dist/style.css';
+	}
+
+	private function compile_once( string $compiled_filename, callable $compiler ): bool {
+		$method = ( new \ReflectionClass( Assets::class ) )->getMethod( 'compile_once' );
+
+		return (bool) $method->invoke( null, $compiled_filename, $compiler );
 	}
 }


### PR DESCRIPTION
Fixes #83.

Elects one compiler per cold compiled asset, mirroring the `Single_Flight` election `Build::init()` already uses for the runtime build.

## The change

`Assets::process_css()` and `process_js()` wrapped their result in `Single_Flight::publish()`, which makes the *write* atomic but leaves the *compile* unguarded: concurrent requests on a missing compiled file each run the full SCSS compile plus minify, then all publish identical bytes.

A new private `Assets::compile_once()` acquires the per-file lock keyed on the compiled filename, has losers wait up to `COMPILE_WAIT_BUDGET_MS` (5000, matching `Build::BUILD_WAIT_BUDGET_MS`) for the published file to appear, and re-attempts the election once before compiling unguarded, so asset processing always completes. `Single_Flight::publish()` still does the write, unchanged.

One deliberate behaviour change in `process_js()`: the `! file_exists( $compiled_filename )` guard before the publish is gone. A file published by a concurrent request between the warm check and that point must return the filenames, as the warm path does, rather than falling through to `void` and silently dropping the asset. The minify now also only runs when the `$minify_js || $has_es_modules || $has_css_modules` gate passes, instead of unconditionally.

## Correction to the mechanism described in #83

The issue says every concurrent request on a missing compiled file compiles. Counting actual compiles since then (via `blockstudio/assets/process/css/content`, which only fires on the cold path) refined that, and I would rather the record be right:

With the runtime build cache enabled, `Build::init()`'s own election usually shields the asset phase, and a plain `_dist` wipe does not herd. One PID compiles while the others wait, so the near-identical wall times in the issue were mostly waiting, not compiling.

The unguarded compile is reached when that shield is absent:

- the runtime build cache is disabled (`cache.enabled: false`), which removes the election entirely, so every request runs the asset phase;
- any waiter that exceeds `BUILD_WAIT_BUDGET_MS` and falls through to a full unguarded build. That is precisely the post-deploy-under-load case, where each fall-through adds a whole duplicate compile pass and deepens the overload that caused the timeout.

## Measurements

v7.6.8, 6 concurrent requests after wiping `_dist`, 58-block classic theme, runtime cache disabled to expose the path deterministically. Compiles counted through the content filter.

|  | CSS compiles | per-request wall time |
|---|---|---|
| One full pass (reference) | 59 | |
| Unpatched | 266 across 5 PIDs | ~0.95 to 1.10s |
| Patched | 60 across 2 PIDs | ~0.71 to 0.83s |
| Warm | 0 | ~0.08 to 0.15s |

Repeat runs land in the same shape (unpatched 227 to 266, patched 60 to 61). The patched extras are the designed wait-budget fall-through. A second theme (72 blocks, 7.5.2) showed the same asymmetry at roughly 1.9s per request unpatched.

This code has been running in production on a worker-capped managed host since 29 August, applied as a Composer patch against v7.6.8.

## Tests

Four cases added to `tests/unit/assets/AssetsTest.php` covering `compile_once`: a cold compile publishes and calls the compiler once; an already-published file skips the compiler; a request contending with a held lock over a published file skips the compiler; the lock is released afterwards. `flock()` locks an open file description, so the contention case is genuine within a single process.

## Checks run locally

- `composer cs`: clean
- `vendor/bin/phpstan analyse --memory-limit=2G`: no errors
- `vendor/bin/phpunit --filter AssetsTest` inside wp-env: green, including the existing `test_process_css_*` cases that pin the uncontended path

CI triggers on pushes to `main` and `7.*` rather than on pull requests, so nothing runs here automatically.

## Happy to change

If you would rather the election live in `Single_Flight` as something like `ensure_file()` next to `read_or_build()`, so `build.php` and `assets.php` share one implementation, say the word and I will move it. I kept it inside `Assets` to keep the fix small.
